### PR TITLE
Add ideal.II to Applications

### DIFF
--- a/docs/gallery_applications/applications.md
+++ b/docs/gallery_applications/applications.md
@@ -10,6 +10,7 @@ There are many outstanding applications that make use of deal.II. This is just a
 - [DOpElib](https://winnifried.github.io/dopelib/)
 - [ExaDG](https://github.com/exadg/exadg)
 - [hyper.deal](https://github.com/hyperdeal/hyperdeal)
+- [ideal.II](https://instatdealii.github.io/idealii/dev/)
 - [Lethe](https://github.com/lethe-cfd/lethe)
 - [life<sup>x</sup>](https://lifex.gitlab.io/)
 - [OpenFCST](http://www.openfcst.mece.ualberta.ca/)


### PR DESCRIPTION
ideal.II has been released in version 1.0.0 with quite a bit of work going into the documentation of the tutorial examples.

Of course I don't know the criteria for being listed in the applications but I would be happy to see it linked there :)