### PR TITLE
mobile navigation improvements

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,3 +1,8 @@
+[News](news.md){ .md-button #mobile-nav-button }
+[Getting Help](/getting_help/){ .md-button #mobile-nav-button }
+[Community](/community/){ .md-button #mobile-nav-button }
+[Funding](/about/funding/){ .md-button #mobile-nav-button }
+
 About
 =======
 

--- a/docs/community/index.md
+++ b/docs/community/index.md
@@ -1,5 +1,14 @@
-Participate
+[Team](team.md){ .md-button #mobile-nav-button }
+[Publications](publications.md){ .md-button #mobile-nav-button }
+[Best papers](best_paper_award.md){ .md-button #mobile-nav-button }
+
+Community
 ===========
+
+
+
+How to participate?
+-------------------
 
 deal.II is a community project that lives by the participation of its members — i.e., including you! If you want to join us in this, here are a few ways to give back to the project:
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -19,3 +19,20 @@
   border: 2px solid black;
   background: lightgray;
 }
+
+/* Navigation for sub-pages are only visible on mobile */
+#mobile-nav-button {
+display: none;
+}
+
+@media screen and (max-width: 76.1875em) {
+  /* Force the navigation tabs to be visible on mobile devices. */
+  .md-tabs {
+    display: block;
+  }
+  /* Show the navigation buttons for sub-pages */
+  #mobile-nav-button {
+    display: inline;
+    padding: 0.4em;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,7 +21,7 @@ nav:
       - Publications: community/publications.md
       - Best papers: community/best_paper_award.md
     - Funding: about/funding.md
-  - Current Release (9.6):
+  - Current Release:
     - current_release/index.md
     - Download: current_release/download.md
     - README: https://www.dealii.org/current/readme.html


### PR DESCRIPTION
On mobile (or narrow windows on desktop), it is very difficult to navigate our website and discover the structure of pages and subpages as one has to click on ``hamburger`` -> ``about``, then ``hamburger`` -> ``community``, then ``hamburger`` -> ``publications`` to find the publication list.

Instead, this PR will:
- always show the top tab-style navigation bar (home, about, current release, etc.)
- add buttons that only show when the sidebar menu is hidden that help you navigate to subpages

Note that the hamburger menu still exists and works the same way.

Screenshot after clicking on about before:
<img width="919" height="279" alt="image" src="https://github.com/user-attachments/assets/0f4ca4b1-0493-4261-aaa4-9a1e20df9df0" />

after:
<img width="916" height="417" alt="image" src="https://github.com/user-attachments/assets/a73d453c-10a4-44b8-afef-84607d045ee0" />

